### PR TITLE
Symbicache fix and documentation typos

### DIFF
--- a/docs/f4pga/modules/index.md
+++ b/docs/f4pga/modules/index.md
@@ -232,7 +232,7 @@ described in `outputs` should be present.
 
 ### Module initialization/instantiation
 
-In the the `__init__` method of module's class, the following fields should be
+In the `__init__` method of module's class, the following fields should be
 set:
 
 * `takes` - a list of symbolic dependency names for dependencies used by the module

--- a/docs/flows/pnr.rst
+++ b/docs/flows/pnr.rst
@@ -34,7 +34,7 @@ step to find more optimal solutions.
 Routing
 =======
 
-Routing is one of the most demanding tasks of the the whole process.
+Routing is one of the most demanding tasks of the whole process.
 All possible connections between the placed blocks and the information on
 the signals propagation timings, form a complex graph.
 The tool tries to find the optimal path connecting all the placed

--- a/f4pga/cache.py
+++ b/f4pga/cache.py
@@ -100,4 +100,4 @@ This will cause flow to re-execute from the beggining.""")
     def save(self):
         """Saves cache's state to the persistent storage."""
         with Path(self.cachefile_path).open('w') as wfptr:
-            json_dump(str(self.hashes), wfptr, indent=4)
+            json_dump(self.hashes, wfptr, indent=4)


### PR DESCRIPTION
hashes field is a dictionary, so wrapping it in a string before saving to file causes a runtime error when loading back into memory