### PR TITLE
Remove platform option

### DIFF
--- a/.github/sftest.json
+++ b/.github/sftest.json
@@ -1,5 +1,5 @@
 {
-    "default_platform": "xc7a50t",
+    "default_part": "XC7A35TCSG324-1",
     "values": {
         "top": "top"
     },
@@ -10,25 +10,7 @@
         "synth_log": "synth.log",
         "pack_log": "pack.log"
     },
-    "xc7a200t": {
-        "default_target": "bitstream",
-        "dependencies": {
-            "xdc": [
-                "xc7/counter_test/arty200.xdc"
-            ],
-            "build_dir": "build/arty_200"
-        }
-    },
-    "xc7a100t": {
-        "default_target": "bitstream",
-        "dependencies": {
-            "xdc": [
-                "xc7/counter_test/arty.xdc"
-            ],
-            "build_dir": "build/arty100"
-        }
-    },
-    "xc7a50t": {
+    "XC7A35TCSG324-1": {
         "default_target": "bitstream",
         "dependencies": {
             "build_dir": "build/arty_35",

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -160,14 +160,13 @@ jobs:
           . ./.github/scripts/activate.sh
 
           cd f4pga-examples
-          f4pga build --flow ../.github/sftest.json -t bitstream
+          f4pga build --flow ../.github/sftest.json
 
       - name: '📤 Upload artifact: Arty 35 bitstream'
         uses: actions/upload-artifact@v3
         with:
           name: arty_35-Bitstream-pyF4PGA
           path: f4pga-examples/build/arty_35/top.bit
-
 
   PYTHONPATH:
     runs-on: ubuntu-latest

--- a/docs/f4pga/Usage.md
+++ b/docs/f4pga/Usage.md
@@ -137,7 +137,7 @@ For example, let's consider the following *projects flow configuration (flow.jso
 
 ```json
 {
-    "default_platform": "xc7a50t",
+    "default_part": "XC7A35TCSG324-1",
     "dependencies": {
         "sources": ["counter.v"],
         "xdc": ["arty.xdc"],
@@ -147,7 +147,7 @@ For example, let's consider the following *projects flow configuration (flow.jso
     "values": {
         "top": "top"
     },
-    "xc7a50t": {
+    "XC7A35TCSG324-1": {
         "default_target": "bitstream",
         "dependencies": {
             "build_dir": "build/arty_35"
@@ -176,7 +176,7 @@ following command:
 $ f4pga build -f flow.json -p XC7A35TCSG324-1 -t bitstream
 ```
 
-Because we have `default_platform` defined, we can skip the `--platform` or `--part` argument.
+Because we have `default_platform` defined, we can skip the `--part` argument.
 We can also skip the `--target` argument because we have a `default_target` defined for the
 chosen platform. This will default to the `bitstream` target of `xc7a50t` platform:
 
@@ -189,7 +189,7 @@ $ f4pga build -f flow.json
 Alternatively you can use CLI to pass the configuration without creating a flow file:
 
 ```
-$ f4pga build -p XC7A35TCSG324-1 -Dsources=[counter.v] -Dxdc=[arty.xdc] -Dsynth_log=synth.log -Dpack_log=pack.log -Dbuild_dir=buils/arty_35 -Vtop=top -t bitstream
+$ f4pga build -p XC7A35TCSG324-1 -Dsources=[counter.v] -Dxdc=[arty.xdc] -Dsynth_log=synth.log -Dpack_log=pack.log -Dbuild_dir=build/arty_35 -Vtop=top -t bitstream
 ```
 
 CLI flow configuration can be used alongside a flow configuration file and will override
@@ -230,7 +230,7 @@ _on-demand_ is currently displayed.
 Example:
 
 ```bash
-$ f4pga -v build flow.json --platform x7a50t -i
+$ f4pga -v build -f flow.json -p XC7A35TCSG324-1 -i
 ```
 
 ```
@@ -273,8 +273,7 @@ This is only a snippet of the entire output.
 | long        | short | arguments                | description                                             |
 |-------------|:-----:|--------------------------|---------------------------------------------------------|
 | --flow      | -f    | flow configuration file  | Use flow configuration file                             |
-| --platform  |       | platform name            | Specify target platform name (eg. x7a100t)              |
-| --part      | -p    | part name                | Specify target platform by part name                    |
+| --part      | -p    | part name                | Specify target part name                                |
 | --target    | -t    | target dependency name   | Specify target to produce                               |
 | --info      | -i    | -                        | Display information about available targets             |
 | --pretend   | -P    | -                        | Resolve dependencies without executing the flow         |
@@ -285,11 +284,11 @@ This is only a snippet of the entire output.
 
 ### Summary of all options available for `showd` sub-command
 
-| long        | short | arguments                | description                                                              |
-|-------------|:-----:|--------------------------|--------------------------------------------------------------------------|
-| --flow      | -f    | flow configuration file  | Use flow configuration file                                              |
-| --platform  | -p    | platform name            | Specify target platform name (to display platform-specific dependencies) |
-| --stage     | -s    | part name                | Specify stage name (to display stage-specific dependencies)              |      
+| long        | short | arguments                | description                                                 |
+|-------------|:-----:|--------------------------|-------------------------------------------------------------|
+| --flow      | -f    | flow configuration file  | Use flow configuration file                                 |
+| --part      | -p    | part name                | Specify target part name                                    |
+| --stage     | -s    | part name                | Specify stage name (to display stage-specific dependencies) |      
 
 ### Dependency resolution display
 

--- a/f4pga/__init__.py
+++ b/f4pga/__init__.py
@@ -11,7 +11,7 @@ The flow defeinition file list modules available for that platform and may tweak
 
 A basic example of using F4PGA:
 
-$ f4pga build --platform arty_35 -t bitstream
+$ f4pga build --flow flow.json --part XC7A35TCSG324-1 -t bitstream
 
 This will make F4PGA attempt to create a bitstream for arty_35 platform.
 ``flow.json`` is a flow configuration file, which should be created for a project that uses F4PGA.

--- a/f4pga/__init__.py
+++ b/f4pga/__init__.py
@@ -41,8 +41,7 @@ from f4pga.flow_config import (
     FlowConfig,
     FlowDefinition,
     open_project_flow_cfg,
-    verify_platform_name,
-    verify_stage
+    verify_platform_name
 )
 from f4pga.module_runner import *
 from f4pga.module_inspector import get_module_info
@@ -122,8 +121,8 @@ def get_stage_values_override(og_values: dict, stage: Stage):
 def prepare_stage_io_input(stage: Stage):
     return { 'params': stage.params } if stage.params is not None else {}
 
-def prepare_stage_input(stage: Stage, platform_name: str, values: dict,
-                        dep_paths: 'dict[str, ]', config_paths: 'dict[str, ]'):
+def prepare_stage_input(stage: Stage, values: dict, dep_paths: 'dict[str, ]',
+                        config_paths: 'dict[str, ]'):
     takes = {}
     for take in stage.takes:
         paths = dep_paths.get(take.name)
@@ -140,8 +139,7 @@ def prepare_stage_input(stage: Stage, platform_name: str, values: dict,
     stage_mod_cfg = {
         'takes': takes,
         'produces': produces,
-        'values': values,
-        'platform': platform_name,
+        'values': values
     }
 
     return stage_mod_cfg
@@ -194,11 +192,11 @@ def _print_unreachable_stage_message(provider: Stage, take: str):
                'unreachable due to unmet dependency '
               f'`{Style.BRIGHT + take.name + Style.RESET_ALL}`')
 
-def config_mod_runctx(stage: Stage, platform_name: str, values: 'dict[str, ]',
+def config_mod_runctx(stage: Stage, values: 'dict[str, ]',
                       dep_paths: 'dict[str, str | list[str]]',
                       config_paths: 'dict[str, str | list[str]]'):
-    config = prepare_stage_input(stage, platform_name, values,
-                                  dep_paths, config_paths)
+    config = prepare_stage_input(stage, values,
+                                 dep_paths, config_paths)
     return ModRunCtx(share_dir_path, binpath, config)
 
 class Flow:
@@ -278,8 +276,7 @@ class Flow:
                 self.deps_rebuilds[take.name] += 1
 
         stage_values = self.cfg.get_r_env(provider.name).values
-        modrunctx = config_mod_runctx(provider, self.cfg.platform,
-                                      stage_values, self.dep_paths,
+        modrunctx = config_mod_runctx(provider, stage_values, self.dep_paths,
                                       self.cfg.get_dependency_overrides())
 
         outputs = module_map(provider.module, modrunctx)
@@ -358,7 +355,7 @@ class Flow:
         else:
             assert(provider)
 
-            any_dep_differ = False if self.symbicache else True
+            any_dep_differ = False if (self.symbicache is not None) else True
             for p_dep in provider.takes:
                 if not self._build_dep(p_dep.name):
                     assert (p_dep.spec != 'req')
@@ -382,8 +379,7 @@ class Flow:
                 return True
 
             stage_values = self.cfg.get_r_env(provider.name).values
-            modrunctx = config_mod_runctx(provider, self.cfg.platform,
-                                          stage_values, self.dep_paths,
+            modrunctx = config_mod_runctx(provider, stage_values, self.dep_paths,
                                           self.cfg.get_dependency_overrides())
             module_exec(provider.module, modrunctx)
 
@@ -497,21 +493,15 @@ def open_project_flow_config(path: str) -> ProjectFlowConfig:
         fatal(-1, 'The provided flow configuration file does not exist')
     return flow_cfg
 
-def verify_platform_stage_params(flow_cfg: FlowConfig,
-                                 platform: 'str | None' = None,
-                                 stage: 'str | None' = None):
-    if platform:
-        if not verify_platform_name(platform, mypath):
-            sfprint(0, f'Platform `{platform}`` is unsupported.')
+def verify_part_stage_params(flow_cfg: FlowConfig,
+                             part: 'str | None' = None):
+    if part:
+        platform_name = get_platform_name_for_part(part)
+        if not verify_platform_name(platform_name, mypath):
+            sfprint(0, f'Platform `{part}`` is unsupported.')
             return False
-        if args.platform not in flow_cfg.platforms():
-            sfprint(0, f'Platform `{platform}`` is not in project.')
-            return False
-
-    if stage:
-        if not verify_stage(platform, stage, mypath):
-            sfprint(0, f'Stage `{stage}` is invalid.')
-            sfbuild_fail()
+        if part not in flow_cfg.part():
+            sfprint(0, f'Platform `{part}`` is not in project.')
             return False
 
     return True
@@ -530,24 +520,28 @@ def cmd_build(args: Namespace):
 
     project_flow_cfg: ProjectFlowConfig = None
 
-    platform = args.platform
-    if platform is None:
-        if args.part:
-            platform = get_platform_name_for_part(args.part)
+    platform: 'str | None' = None
+    part_name = args.part
+    if args.part:
+        platform = get_platform_name_for_part(args.part)
 
     if args.flow:
         project_flow_cfg = open_project_flow_config(args.flow)
-    elif platform is not None:
+    elif part_name is not None:
         project_flow_cfg = ProjectFlowConfig('.temp.flow.json')
         project_flow_cfg.flow_cfg = get_cli_flow_config(args, platform)
-    if platform is None and project_flow_cfg is not None:
-        platform = project_flow_cfg.get_default_platform()
-        if platform is None:
-            fatal(-1, 'You have to specify a platform name or a part name or '
-                      'configure a default platform.')
-    if platform is None or project_flow_cfg is None:
-        fatal(-1, 'No configuration was provided. Use `--flow`, `--platform` or '
-                  '`--part` to configure flow..')
+    if part_name is None and project_flow_cfg is not None:
+        part_name = project_flow_cfg.get_default_part()
+    
+    platform = get_platform_name_for_part(part_name)
+    if platform is None:
+        fatal(-1, 'You have to specify a part name or configure a default part.')
+    if project_flow_cfg is None:
+        fatal(-1, 'No configuration was provided. Use `--flow`, and/or '
+                  '`--part` to configure flow.')
+    
+    if part_name not in project_flow_cfg.parts():
+        fatal('Project flow configuration does not support requested part.')
 
     platform_path = str(Path(mypath) / f'platforms/{platform}.json')
     platform_def = None
@@ -560,13 +554,14 @@ def cmd_build(args: Namespace):
             'cannot be found.')
 
     r_env = setup_resolution_env()
+    r_env.add_values({'part_name': part_name.lower()})
 
     sfprint(2, 'Scanning modules...')
     scan_modules(mypath)
 
     flow_definition_dict = json_loads(platform_def)
     flow_def = FlowDefinition(flow_definition_dict, r_env)
-    flow_cfg = FlowConfig(project_flow_cfg, flow_def, platform)
+    flow_cfg = FlowConfig(project_flow_cfg, flow_def, part_name)
 
 
     if len(flow_cfg.stages) == 0:
@@ -582,7 +577,7 @@ def cmd_build(args: Namespace):
 
     target = args.target
     if target is None:
-        target = project_flow_cfg.get_default_target(platform)
+        target = project_flow_cfg.get_default_target(part_name)
         if target is None:
             fatal(-1, 'Please specify desired target using `--target` option '
                       'or configure a default target.')
@@ -615,14 +610,14 @@ def cmd_show_dependencies(args: Namespace):
 
     flow_cfg = open_project_flow_config(args.flow)
 
-    if not verify_platform_stage_params(flow_cfg, args.platform):
+    if not verify_part_stage_params(flow_cfg, args.part):
         sfbuild_fail()
         return
 
     platform_overrides: 'set | None' = None
     if args.platform is not None:
         platform_overrides = \
-            set(flow_cfg.get_dependency_platform_overrides(args.platform).keys())
+            set(flow_cfg.get_dependency_platform_overrides(args.part).keys())
 
     display_list = []
 

--- a/f4pga/argparser.py
+++ b/f4pga/argparser.py
@@ -24,12 +24,6 @@ def _setup_build_parser(parser: ArgumentParser):
     )
 
     parser.add_argument(
-        '--platform',
-        metavar='platform_name',
-        help='Target platform_name'
-    )
-
-    parser.add_argument(
         '-P',
         '--pretend',
         action='store_true',
@@ -82,10 +76,10 @@ def _setup_build_parser(parser: ArgumentParser):
 def _setup_show_dep_parser(parser: ArgumentParser):
     parser.add_argument(
         '-p',
-        '--platform',
-        metavar='platform_name',
+        '--part',
+        metavar='part_name',
         type=str,
-        help='Name of the platform (use to display platform-specific values.)'
+        help='Name of the part (use to display part-specific values.)'
     )
 
     parser.add_argument(
@@ -274,28 +268,28 @@ def _parse_cli_value(s: str):
     return s.replace('\\', '')
 
 
-def get_cli_flow_config(args: Namespace, platform: str):
+def get_cli_flow_config(args: Namespace, part: str):
     def create_defdict():
         return {
             'dependencies': {},
             'values': {},
         }
 
-    platform_flow_config = create_defdict()
+    part_flow_config = create_defdict()
 
     def add_entries(arglist: 'list[str]', dict_name: str):
         for value_def in (_parse_depval(cliv) for cliv in arglist):
             stage = value_def['stage']
             if stage is None:
-                platform_flow_config[dict_name][value_def['name']] = \
+                part_flow_config[dict_name][value_def['name']] = \
                     value_def['value']
             else:
-                if platform_flow_config.get(stage) is None:
-                    platform_flow_config[stage] = create_defdict()
-                platform_flow_config[stage][dict_name][value_def['name']] = \
+                if part_flow_config.get(stage) is None:
+                    part_flow_config[stage] = create_defdict()
+                part_flow_config[stage][dict_name][value_def['name']] = \
                     value_def['value']
 
     add_entries(args.dep, 'dependencies')
     add_entries(args.val, 'values')
 
-    return { platform: platform_flow_config }
+    return { part: part_flow_config }

--- a/f4pga/module.py
+++ b/f4pga/module.py
@@ -7,7 +7,8 @@ from abc import abstractmethod
 
 from f4pga.common import (
     decompose_depname,
-    ResolutionEnv
+    ResolutionEnv,
+    fatal
 )
 
 

--- a/f4pga/platforms/ql-eos-s3.json
+++ b/f4pga/platforms/ql-eos-s3.json
@@ -11,7 +11,6 @@
     },
 
     "values": {
-        "part_name": "pd64",
         "device": "ql-eos-s3",
         "device_alt": "ql-eos-s3_wlcsp",
         "pinmap": "${shareDir}/arch/ql-eos-s3_wlcsp/pinmap_PD64.csv",

--- a/f4pga/platforms/ql-k4n8_fast.json
+++ b/f4pga/platforms/ql-k4n8_fast.json
@@ -12,7 +12,6 @@
     },
 
     "values": {
-        "part_name": "k4n8",
         "device": "qlf_k4n8_umc22",
         "rr_graph_lookahead_bin": "${shareDir}/arch/qlf_k4n8-qlf_k4n8_umc22_fast_qlf_k4n8-qlf_k4n8_umc22_fast/rr_graph_qlf_k4n8-qlf_k4n8_umc22_fast_qlf_k4n8-qlf_k4n8_umc22_fast.lookahead.bin",
         "rr_graph_real_bin": "${shareDir}/arch/qlf_k4n8-qlf_k4n8_umc22_fast_qlf_k4n8-qlf_k4n8_umc22_fast/qlf_k4n8-qlf_k4n8_umc22_fast.rr_graph.bin",

--- a/f4pga/platforms/ql-k4n8_slow.json
+++ b/f4pga/platforms/ql-k4n8_slow.json
@@ -12,7 +12,6 @@
     },
 
     "values": {
-        "part_name": "k4n8",
         "device": "qlf_k4n8_umc22",
         "rr_graph_lookahead_bin": "${shareDir}/arch/qlf_k4n8-qlf_k4n8_umc22_slow_qlf_k4n8-qlf_k4n8_umc22_slow/rr_graph_qlf_k4n8-qlf_k4n8_umc22_slow_qlf_k4n8-qlf_k4n8_umc22_slow.lookahead.bin",
         "rr_graph_real_bin": "${shareDir}/arch/qlf_k4n8-qlf_k4n8_umc22_slow_qlf_k4n8-qlf_k4n8_umc22_slow/qlf_k4n8-qlf_k4n8_umc22_slow.rr_graph.bin",

--- a/f4pga/platforms/xc7a100t.json
+++ b/f4pga/platforms/xc7a100t.json
@@ -1,6 +1,5 @@
 {
     "values": {
-        "part_name": "xc7a100tcsg324-1",
         "device": "xc7a100t_test",
         "bitstream_device": "artix7",
         "pinmap": "${shareDir}/arch/xc7a100t_test/vpr_grid_map.csv",

--- a/f4pga/platforms/xc7a200t.json
+++ b/f4pga/platforms/xc7a200t.json
@@ -1,6 +1,5 @@
 {
     "values": {
-        "part_name": "xc7a200tsbg484-1",
         "device": "xc7a200t_test",
         "bitstream_device": "artix7",
         "pinmap": "${shareDir}/arch/xc7a200t_test/vpr_grid_map.csv",

--- a/f4pga/platforms/xc7a50t.json
+++ b/f4pga/platforms/xc7a50t.json
@@ -12,7 +12,6 @@
     },
 
     "values": {
-        "part_name": "xc7a35tcsg324-1",
         "device": "xc7a50t_test",
         "bitstream_device": "artix7",
         "pinmap": "${shareDir}/arch/xc7a50t_test/vpr_grid_map.csv",


### PR DESCRIPTION
Solves #565

**THIS IS A BREAKING CHANGE:**
* `--platform` option has been removed
* Flow configurations can't refer to platfom names. Part names are used instead.
* `default_platform` flow config entry has been removed. Use `default_part` instead.