### PR TITLE
Fix symbicache

### DIFF
--- a/docs/f4pga/DevNotes.md
+++ b/docs/f4pga/DevNotes.md
@@ -58,8 +58,8 @@ particular consumer. This is necessary, because the system tries to avoid rebuil
 when possible and status of each file (modified/unmodified) may differ in regards
 to individual stages.
 
-Keeping track of status of each file is done using `SymbiCache` class, which is
-defined in `sf_cache.py` file. `SymbiCache` is used mostly inside `Flow`'s methods.
+Keeping track of status of each file is done using `F4Cache` class, which is
+defined in `cache.py` file. `F4Cache` is used mostly inside `Flow`'s methods.
 
 ### Internal environmental variable system
 

--- a/docs/f4pga/Usage.md
+++ b/docs/f4pga/Usage.md
@@ -71,21 +71,21 @@ file or derived from the paths of the dependencies taken by the module.
 
 A *flow* is set of *modules* executed in a right order to produce a *target*.
 
-### .symbicache
+### .f4cache
 
 All *dependencies* are tracked by a modification tracking system which stores hashes of the files
-(directories get always `'0'` hash) in `.symbicache` file in the root of the project.
+(directories get always `'0'` hash) in `.f4cache` file in the root of the project.
 When F4PGA constructs a *flow*, it will try to omit execution of modules which would receive the same data on their
 input.
 There is a strong _assumption_ there that a *module*'s output remains unchanged if the input configuration isn't
 changed, ie. *modules* are deterministic. This is might be not true for some tools and in case you really want to re-run
-a stage, there's a `--nocache` option that treats the `.symbicache` file as if it was empty.
+a stage, there's a `--nocache` option that treats the `.f4cache` file as if it was empty.
 
 ### Resolution
 
 A *dependency* is said to be *resolved* if it meets one of the following criteria:
 
-* it exists on persistent storage and its hash matches the one stored in .symbicache
+* it exists on persistent storage and its hash matches the one stored in .f4cache
 * there exists such *flow* that all of the dependencies of its modules are *resolved* and it produces the *dependency* in
   question.
 

--- a/f4pga/__init__.py
+++ b/f4pga/__init__.py
@@ -82,7 +82,7 @@ def req_exists(r):
     """ Checks whether a dependency exists on a drive. """
 
     if type(r) is str:
-        if not Path(r).is_file() and not Path(r).is_symlink() and not Path(r).is_dir():
+        if not Path(r).exists():
             return False
     elif type(r) is list:
         return not (False in map(req_exists, r))
@@ -146,7 +146,7 @@ def prepare_stage_input(stage: Stage, values: dict, dep_paths: 'dict[str, ]',
 
 def update_dep_statuses(paths, consumer: str, symbicache: SymbiCache):
     if type(paths) is str:
-        return symbicache.update(paths, consumer)
+        return symbicache.update(Path(paths), consumer)
     elif type(paths) is list:
         for p in paths:
             return update_dep_statuses(p, consumer, symbicache)
@@ -163,8 +163,6 @@ def dep_differ(paths, consumer: str, symbicache: SymbiCache):
 
     if type(paths) is str:
         s = symbicache.get_status(paths, consumer)
-        if s == 'untracked':
-            symbicache.update(paths, consumer)
         return symbicache.get_status(paths, consumer) != 'same'
     elif type(paths) is list:
         return True in [dep_differ(p, consumer, symbicache) for p in paths]
@@ -361,7 +359,7 @@ class Flow:
                     assert (p_dep.spec != 'req')
                     continue
 
-                if self.symbicache:
+                if self.symbicache is not None:
                     any_dep_differ |= \
                         update_dep_statuses(self.dep_paths[p_dep.name],
                                             provider.name, self.symbicache)

--- a/f4pga/cache.py
+++ b/f4pga/cache.py
@@ -4,6 +4,12 @@ from json import dump as json_dump, load as json_load, JSONDecodeError
 
 from f4pga.common import sfprint
 
+def _get_hash(path: Path):
+    if not path.is_dir():
+        with path.open('rb') as rfptr:
+            return zlib_adler32(rfptr.read())
+    return 0 # Directories always get '0' hash.
+
 class F4Cache:
     """
     `F4Cache` is used to track changes among dependencies and keep the status of the files on a persistent storage.
@@ -12,6 +18,7 @@ class F4Cache:
     """
 
     hashes: 'dict[str, dict[str, str]]'
+    current_hashes: 'dict[str, str]'
     status: 'dict[str, str]'
     cachefile_path: str
 
@@ -21,6 +28,7 @@ class F4Cache:
         """
 
         self.status = {}
+        self.current_hashes = {}
         self.cachefile_path = cachefile_path
         self.load()
 
@@ -42,6 +50,12 @@ class F4Cache:
         if not self.status.get(path):
             self.status[path] = {}
         self.status[path][consumer] = status
+    
+    def process_file(self, path: Path):
+        """ Process file for tracking with f4cache. """
+
+        hash = _get_hash(path)
+        self.current_hashes[path.as_posix()] = hash
 
     def update(self, path: Path, consumer: str):
         """ Add/remove a file to.from the tracked files, update checksum if necessary and calculate status.
@@ -51,34 +65,41 @@ class F4Cache:
         by a module within the active flow.
         """
 
-        exists = path.exists()
+        posix_path = path.as_posix()
 
-        isdir = path.is_dir()
-        if not exists:
-            self._try_pop_consumer(path.as_posix(), consumer)
+        assert self.current_hashes.get(posix_path) is not None
+
+        if not path.exists():
+            self._try_pop_consumer(posix_path, consumer)
             return True
-        hash = 0 # Directories always get '0' hash.
-        if (not isdir) and exists:
-            with path.open('rb') as rfptr:
-                hash = str(zlib_adler32(rfptr.read()))
 
-        last_hashes = self.hashes.get(path.as_posix())
+        hash = self.current_hashes[posix_path]
+        last_hashes = self.hashes.get(posix_path)
         last_hash = None if last_hashes is None else last_hashes.get(consumer)
 
         if hash != last_hash:
-            self._try_push_consumer_status(path.as_posix(), consumer, 'changed')
-            self._try_push_consumer_hash(path.as_posix(), consumer, hash)
+            self._try_push_consumer_status(posix_path, consumer, 'changed')
+            self._try_push_consumer_hash(posix_path, consumer, hash)
             return True
-        self._try_push_consumer_status(path.as_posix(), consumer, 'same')
+        self._try_push_consumer_status(posix_path, consumer, 'same')
         return False
 
     def get_status(self, path: str, consumer: str):
         """ Get status for a file with a given path.
-        returns 'untracked' if the file is not tracked or hasn't been treated with `update` procedure before calling
-        `get_status`.
+        returns 'untracked' if the file is not tracked.
         """
+
+        assert self.current_hashes.get(path) is not None
+
         statuses = self.status.get(path)
         if not statuses:
+            hashes = self.hashes.get(path)
+            if hashes is not None:
+                last_hash = hashes.get(consumer)
+                if last_hash is not None:
+                    if self.current_hashes[path] != last_hash:
+                        return 'changed'
+                    return 'same'
             return 'untracked'
         status = statuses.get(consumer)
         if not status:

--- a/f4pga/cache.py
+++ b/f4pga/cache.py
@@ -4,9 +4,9 @@ from json import dump as json_dump, load as json_load, JSONDecodeError
 
 from f4pga.common import sfprint
 
-class SymbiCache:
+class F4Cache:
     """
-    `SymbiCache` is used to track changes among dependencies and keep the status of the files on a persistent storage.
+    `F4Cache` is used to track changes among dependencies and keep the status of the files on a persistent storage.
     Files which are tracked get their checksums calculated and stored in a file.
     If file's checksum differs from the one saved in a file, that means, the file has changed.
     """
@@ -91,13 +91,13 @@ class SymbiCache:
         try:
             with Path(self.cachefile_path).open('r') as rfptr:
                 self.hashes = json_load(rfptr)
-        except JSONDecodeError as jerr:
-            sfprint(0, 'WARNING: .symbicache is corrupted!\n'
-                       'This will cause flow to re-execute from the beginning.')
+        except JSONDecodeError:
+            sfprint(0, f'WARNING: `{self.cachefile_path}` f4cache is corrupted!\n'
+                        'This will cause flow to re-execute from the beginning.')
             self.hashes = {}
         except FileNotFoundError:
-            sfprint(0, 'Couldn\'t open .symbicache cache file.\n'
-                       'This will cause flow to re-execute from the beginning.')
+            sfprint(0, f'Couldn\'t open `{self.cachefile_path}` cache file.\n'
+                        'This will cause flow to re-execute from the beginning.')
             self.hashes = {}
 
     def save(self):

--- a/f4pga/common.py
+++ b/f4pga/common.py
@@ -71,11 +71,13 @@ def deep(fun):
     """
     def d(paths, *args, **kwargs):
         if type(paths) is str:
-            return fun(paths)
+            return fun(paths, *args, **kwargs)
         elif type(paths) is list:
-            return [d(p) for p in paths];
+            return [d(p, *args, **kwargs) for p in paths];
         elif type(paths) is dict:
-            return dict([(k, d(p)) for k, p in paths.items()])
+            return dict([(k, d(p, *args, **kwargs)) for k, p in paths.items()])
+        else:
+            raise RuntimeError(f'paths is of type {type(paths)}')
     return d
 
 


### PR DESCRIPTION
~Symbicache~ f4cache gets updated early in `dep_differ`. This caused some false positives when reporting that a dependency "remained unchanged".

-----

Renamed symbicache to f4cache

-----

Fixed issues with reporting project status by allowing the caches to check files without updating. This however, required expicitely reporting those files those files to `F4Cache` as soon as they become available.