### PR TITLE
wrappers: ql: use utility scripts from share dir

### DIFF
--- a/.github/scripts/activate.sh
+++ b/.github/scripts/activate.sh
@@ -20,10 +20,7 @@ set -e
 
 FPGA_FAM=${FPGA_FAM:=xc7}
 
-case "$FPGA_FAM" in
-  xc7) F4PGA_DIR_ROOT='install';;
-  eos-s3) F4PGA_DIR_ROOT='quicklogic-arch-defs';;
-esac
+F4PGA_DIR_ROOT='install'
 
 export PATH="$F4PGA_INSTALL_DIR/$FPGA_FAM/$F4PGA_DIR_ROOT/bin:$PATH"
 source "$F4PGA_INSTALL_DIR/$FPGA_FAM/conda/etc/profile.d/conda.sh"

--- a/.github/scripts/prepare_environment.sh
+++ b/.github/scripts/prepare_environment.sh
@@ -68,10 +68,9 @@ cd ..
 
 
 echo '::group::Add f4pga-env'
-case "$FPGA_FAM" in
-  xc7) F4PGA_DIR_ROOT='install';;
-  eos-s3) F4PGA_DIR_ROOT='quicklogic-arch-defs';;
-esac
+
+F4PGA_DIR_ROOT='install'
+
 F4PGA_DIR_BIN="$F4PGA_INSTALL_DIR_FAM/$F4PGA_DIR_ROOT"/bin/
 mkdir -p "$F4PGA_DIR_BIN"
 cp $(dirname "$0")/../../f4pga-env "$F4PGA_DIR_BIN"

--- a/.github/scripts/prepare_environment.sh
+++ b/.github/scripts/prepare_environment.sh
@@ -48,17 +48,21 @@ echo '::endgroup::'
 
 
 echo '::group::Install arch-defs'
+mkdir -p "$F4PGA_INSTALL_DIR_FAM"/install
 case "$FPGA_FAM" in
   xc7)
-    mkdir -p "$F4PGA_INSTALL_DIR_FAM"/install
     F4PGA_TIMESTAMP='20220714-173445'
     F4PGA_HASH='f7afc12'
     for PKG in install xc7a50t_test; do
-      wget -qO- https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/${F4PGA_TIMESTAMP}/symbiflow-arch-defs-${PKG}-${F4PGA_HASH}.tar.xz | tar -xJC $F4PGA_INSTALL_DIR/xc7/install
+      wget -qO- https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/${F4PGA_TIMESTAMP}/symbiflow-arch-defs-${PKG}-${F4PGA_HASH}.tar.xz | tar -xJC $F4PGA_INSTALL_DIR/$FPGA_FAM/install
     done
   ;;
   eos-s3)
-    wget -qO- https://storage.googleapis.com/symbiflow-arch-defs-install/quicklogic-arch-defs-qlf-fc5d8da.tar.gz | tar -xz -C $F4PGA_INSTALL_DIR_FAM
+    F4PGA_TIMESTAMP='yyyymmdd-hhmmss'   #FIXME: placeholder timestamp
+    F4PGA_HASH='deadbee'                #FIXME: placeholder hash
+    for PKG in install-ql ql-eos-s3_wlcsp; do
+      wget -qO- https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/${F4PGA_TIMESTAMP}/symbiflow-arch-defs-${PKG}-${F4PGA_HASH}.tar.xz | tar -xJC $F4PGA_INSTALL_DIR/$FPGA_FAM/install
+    done
   ;;
 esac
 echo '::endgroup::'

--- a/.github/scripts/prepare_environment.sh
+++ b/.github/scripts/prepare_environment.sh
@@ -80,18 +80,3 @@ echo '::endgroup::'
 cd "$F4PGA_DIR_BIN"
 ls -lah
 
-
-case "$FPGA_FAM" in
-  eos-s3)
-    echo '::group::🗑️ Remove the wrappers (pre-packaged from arch-defs)'
-
-    sed -i 's#${MYPATH}/../share#'"$(./f4pga-env share)"'#' vpr_common
-    rm -vrf \
-      symbiflow_* \
-      vpr_common \
-      ql_symbiflow \
-      env
-    echo '::endgroup::'
-    ls -lah
-  ;;
-esac

--- a/f4pga-env
+++ b/f4pga-env
@@ -11,7 +11,7 @@ case "$1" in
   ;;
   share)
     (
-        cd $(dirname "$0")/../share/symbiflow
+        cd $(dirname "$0")/../share/f4pga
         pwd
     )
   ;;

--- a/f4pga/__init__.py
+++ b/f4pga/__init__.py
@@ -79,9 +79,9 @@ bin_dir_path = \
     environ.get('F4PGA_BIN_DIR', str(Path(sys_argv[0]).resolve().parent.parent))
 share_dir_path = \
     environ.get('F4PGA_SHARE_DIR',
-                str(Path(f'{install_dir}/xc7/install/share/symbiflow').resolve()))
+                str(Path(f'{install_dir}/xc7/install/share/f4pga').resolve()))
 if share_dir_path is None:
-    share_dir_path = str(Path(f'{install_dir}/xc7/install/share/symbiflow').resolve()) 
+    share_dir_path = str(Path(f'{install_dir}/xc7/install/share/f4pga').resolve())
 
 class DependencyNotProducedException(F4PGAException):
     dep_name: str

--- a/f4pga/wrappers/sh/__init__.py
+++ b/f4pga/wrappers/sh/__init__.py
@@ -39,7 +39,7 @@ F4PGA_INSTALL_DIR_PATH = Path(F4PGA_INSTALL_DIR)
 
 f4pga_environ['F4PGA_BIN_DIR'] = f4pga_environ.get('F4PGA_BIN_DIR', str(F4PGA_INSTALL_DIR_PATH / FPGA_FAM / 'conda/bin'))
 f4pga_environ['F4PGA_SHARE_DIR'] = f4pga_environ.get('F4PGA_SHARE_DIR', str(F4PGA_INSTALL_DIR_PATH / FPGA_FAM / (
-    'share' if isQuickLogic else 'install/share/symbiflow'
+    'share' if isQuickLogic else 'install/share/f4pga'
 )))
 
 

--- a/f4pga/wrappers/sh/quicklogic/fasm2bels.f4pga.sh
+++ b/f4pga/wrappers/sh/quicklogic/fasm2bels.f4pga.sh
@@ -71,7 +71,7 @@ fi
 if [[ "$DEVICE" =~ ^(ql-eos-s3|ql-pp3e)$ ]]; then
 
     VPR_DB=`readlink -f ${SHARE_DIR_PATH}/arch/${DEVICE}_wlcsp/db_phy.pickle`
-    FASM2BELS=`readlink -f ${BIN_DIR_PATH}/python/fasm2bels.py`
+    FASM2BELS=`readlink -f ${SHARE_DIR_PATH}/scripts/fasm2bels.py`
     FASM2BELS_DEVICE=${DEVICE/ql-/}
     VERILOG_FILE="${BIT}.v"
     PCF_FILE="${BIT}.v.pcf"

--- a/f4pga/wrappers/sh/quicklogic/generate_constraints.f4pga.sh
+++ b/f4pga/wrappers/sh/quicklogic/generate_constraints.f4pga.sh
@@ -49,7 +49,7 @@ if [[ "$DEVICE" =~ ^(qlf_.*)$ ]]; then
   fi
 
   PINMAP_XML=`realpath ${SHARE_DIR_PATH}/arch/${DEVICE_1}_${DEVICE_1}/${PINMAPXML}`
-  IOGEN=`realpath ${BIN_DIR_PATH}/python/qlf_k4n8_create_ioplace.py`
+  IOGEN=`realpath ${SHARE_DIR_PATH}/scripts/qlf_k4n8_create_ioplace.py`
 
   ${PYTHON3} ${IOGEN} --pcf $PCF --blif $EBLIF --pinmap_xml $PINMAP_XML --csv_file $PART --net $NET > ${IOPLACE_FILE}
 
@@ -71,8 +71,8 @@ elif [[ "$DEVICE" =~ ^(ql-.*)$ ]]; then
   PINMAP=`realpath ${SHARE_DIR_PATH}/arch/${DEVICE_1}_${DEVICE_2}/${PINMAPCSV}`
   CLKMAP=`realpath ${SHARE_DIR_PATH}/arch/${DEVICE_1}_${DEVICE_2}/${CLKMAPCSV}`
 
-  IOGEN=`realpath ${BIN_DIR_PATH}/python/pp3_create_ioplace.py`
-  PLACEGEN=`realpath ${BIN_DIR_PATH}/python/pp3_create_place_constraints.py`
+  IOGEN=`realpath ${SHARE_DIR_PATH}/scripts/pp3_create_ioplace.py`
+  PLACEGEN=`realpath ${SHARE_DIR_PATH}/scripts/pp3_create_place_constraints.py`
 
   PLACE_FILE="${PROJECT%.*}_constraints.place"
 
@@ -82,7 +82,7 @@ elif [[ "$DEVICE" =~ ^(ql-.*)$ ]]; then
   # EOS-S3 IOMUX configuration
   if [[ "$DEVICE" =~ ^(ql-eos-s3)$ ]]; then
 
-      IOMUXGEN=`realpath ${BIN_DIR_PATH}/python/pp3_eos_s3_iomux_config.py`
+      IOMUXGEN=`realpath ${SHARE_DIR_PATH}/scripts/pp3_eos_s3_iomux_config.py`
 
       IOMUX_JLINK="${PROJECT%.*}_iomux.jlink"
       IOMUX_OPENOCD="${PROJECT%.*}_iomux.openocd"

--- a/f4pga/wrappers/sh/quicklogic/generate_libfile.f4pga.sh
+++ b/f4pga/wrappers/sh/quicklogic/generate_libfile.f4pga.sh
@@ -34,7 +34,7 @@ fi
 ARCH_DIR="$F4PGA_SHARE_DIR"/arch/${DEVICE_1}_${DEVICE_1}
 PINMAP_XML=${ARCH_DIR}/${PINMAPXML}
 
-`which python3` "$F4PGA_BIN_DIR"/python/create_lib.py \
+`which python3` "$F4PGA_SHARE_DIR"/scripts/create_lib.py \
   -n ${DEV}_0P72_SSM40 \
   -m fpga_top \
   -c $PART \

--- a/f4pga/wrappers/sh/quicklogic/ql.f4pga.sh
+++ b/f4pga/wrappers/sh/quicklogic/ql.f4pga.sh
@@ -361,7 +361,7 @@ else
   PCF_MAKE="\${current_dir}/${BUILDDIR}/${TOP}_dummy.pcf"
 fi
 
-PROCESS_SDC=$(realpath "$F4PGA_BIN_DIR"/python/process_sdc_constraints.py)
+PROCESS_SDC=$(realpath "$F4PGA_SHARE_DIR"/scripts/process_sdc_constraints.py)
 if ! [ -z "$SDC" ]; then
   if ! [ -f "$SOURCE"/$SDC ];then
     echo "The sdc file: $SDC is missing at: $SOURCE"

--- a/f4pga/wrappers/sh/quicklogic/repack.f4pga.sh
+++ b/f4pga/wrappers/sh/quicklogic/repack.f4pga.sh
@@ -30,9 +30,9 @@ DESIGN=${EBLIF/.eblif/}
 [ ! -z "${JSON}" ] && JSON_ARGS="--json-constraints ${JSON}" || JSON_ARGS=
 [ ! -z "${PCF_PATH}" ] && PCF_ARGS="--pcf-constraints ${PCF_PATH}" || PCF_ARGS=
 
-export PYTHONPATH=$F4PGA_BIN_DIR/python:$PYTHONPATH
+export PYTHONPATH=$F4PGA_SHARE_DIR/scripts:$PYTHONPATH
 
-`which python3` "$F4PGA_BIN_DIR"/python/repacker/repack.py \
+`which python3` "$F4PGA_SHARE_DIR"/scripts/repacker/repack.py \
   --vpr-arch ${ARCH_DEF} \
   --repacking-rules ${ARCH_DIR}/${DEVICE_1}.repacking_rules.json \
   $JSON_ARGS \

--- a/f4pga/wrappers/sh/quicklogic/synth.f4pga.sh
+++ b/f4pga/wrappers/sh/quicklogic/synth.f4pga.sh
@@ -135,7 +135,7 @@ export OUT_SYNTH_V=${TOP}_synth.v
 export OUT_EBLIF=${TOP}.eblif
 export OUT_FASM_EXTRA=${TOP}_fasm_extra.fasm
 export PYTHON3=$(which python3)
-export UTILS_PATH=${VPRPATH}/python/
+export UTILS_PATH=${SHARE_DIR_PATH}/scripts
 
 if [ -s $PCF ]; then
     export PCF_FILE=$PCF

--- a/f4pga/wrappers/sh/quicklogic/synth.f4pga.sh
+++ b/f4pga/wrappers/sh/quicklogic/synth.f4pga.sh
@@ -20,8 +20,8 @@ set -e
 
 export SHARE_DIR_PATH=${SHARE_DIR_PATH:="$F4PGA_SHARE_DIR"}
 VPRPATH=${VPRPATH:="$F4PGA_BIN_DIR"}
-SPLIT_INOUTS=`realpath ${VPRPATH}/python/split_inouts.py`
-CONVERT_OPTS=`realpath ${VPRPATH}/python/convert_compile_opts.py`
+SPLIT_INOUTS=`realpath ${SHARE_DIR_PATH}/scripts/split_inouts.py`
+CONVERT_OPTS=`realpath ${SHARE_DIR_PATH}/scripts/convert_compile_opts.py`
 
 print_usage () {
     echo "Usage: symbiflow_synth  -v|--verilog <Verilog file list>"


### PR DESCRIPTION
This PR changes paths to some python utilities used by deprecated QL toolchain wrappers. This change is required to eliminate inconsistency between f4pga-arch-defs packages for xc7 and eos-s3.
It is a breaking change for deprecated toolchain for QL EOS-S3 to the point of updating f4pga-arch-defs package structure.
It is cross-dependent with: https://github.com/SymbiFlow/f4pga-arch-defs/pull/2821

Signed-off-by: Paweł Czarnecki <pczarnecki@antmicro.com>