### PR TITLE
[fix] Revert share path to the symbiflow one

### DIFF
--- a/f4pga/__init__.py
+++ b/f4pga/__init__.py
@@ -79,9 +79,9 @@ bin_dir_path = \
     environ.get('F4PGA_BIN_DIR', str(Path(sys_argv[0]).resolve().parent.parent))
 share_dir_path = \
     environ.get('F4PGA_SHARE_DIR',
-                str(Path(f'{install_dir}/xc7/install/share/f4pga').resolve()))
+                str(Path(f'{install_dir}/xc7/install/share/symbiflow').resolve()))
 if share_dir_path is None:
-    share_dir_path = str(Path(f'{install_dir}/xc7/install/share/f4pga').resolve())
+    share_dir_path = str(Path(f'{install_dir}/xc7/install/share/symbiflow').resolve())
 
 class DependencyNotProducedException(F4PGAException):
     dep_name: str


### PR DESCRIPTION
Thhe change in path introduced in https://github.com/chipsalliance/f4pga/commit/a56e870082a53132e062ce8894bad33be6095abe breaks compatibility with current packages.

This PR reverts it.