### PR TITLE
Use extra verbose mode for f4pga CI test

### DIFF
--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -116,7 +116,7 @@ jobs:
         run: |
           . ./.github/scripts/activate.sh
           cd f4pga-examples
-          f4pga build --flow ../.github/${{ matrix.fam }}_test.json
+          f4pga -vv build --flow ../.github/${{ matrix.fam }}_test.json
 
       - name: '📤 Upload artifact: ${{ matrix.fam }} bitstream'
         if: matrix.flow == 'F4PGA'


### PR DESCRIPTION
~The current output is very minimal and makes it harder to understand what went wrong in case the CI fails.~