### PR TITLE
Unify stage declarations with stage options

### DIFF
--- a/f4pga/flow_config.py
+++ b/f4pga/flow_config.py
@@ -82,13 +82,9 @@ class FlowDefinition:
             self.r_env.add_values(global_vals)
 
         stages_d = flow_def['stages']
-        modopts_d = flow_def.get('stage_options')
-        if modopts_d is None:
-            modopts_d = {}
 
-        for stage_name, modstr in stages_d.items():
-            opts = modopts_d.get(stage_name)
-            self.stages[stage_name] = Stage(stage_name, modstr, opts)
+        for stage_name, stage_def in stages_d.items():
+            self.stages[stage_name] = Stage(stage_name, stage_def)
 
     def stage_names(self):
         return self.stages.keys()

--- a/f4pga/platforms/ql-eos-s3.json
+++ b/f4pga/platforms/ql-eos-s3.json
@@ -1,26 +1,4 @@
 {
-    "stages": {
-        "mk_build_dir": "common:mkdirs",
-        "synth": "common:synth",
-        "prepare_sdc": "common:generic_script_wrapper",
-        "pack": "common:pack",
-        "ioplace": "common:generic_script_wrapper",
-        "place_constraints": "common:generic_script_wrapper",
-        "iomux_jlink": "common:generic_script_wrapper",
-        "iomux_openocd": "common:generic_script_wrapper",
-        "iomux_binary": "common:generic_script_wrapper",
-        "place": "common:place",
-        "route": "common:route",
-        "analysis": "common:analysis",
-        "fasm": "common:fasm",
-        "bitstream": "common:generic_script_wrapper",
-        "bitstream_bitheader": "common:generic_script_wrapper",
-        "bitstream_binary": "common:generic_script_wrapper",
-        "bitstream_jlink": "common:generic_script_wrapper",
-        "bitstream_openocd": "common:generic_script_wrapper",
-        "fasm2bels": "common:generic_script_wrapper"
-    },
-
     "values": {
         "device": "ql-eos-s3",
         "device_alt": "ql-eos-s3_wlcsp",
@@ -54,13 +32,16 @@
         }
     },
 
-    "stage_options": {
+    "stages": {
         "mk_build_dir": {
+            "module": "common:mkdirs",
             "params": {
                 "build_dir": "build/${device}"
             }
         },
+
         "synth": {
+            "module": "common:synth",
             "params": {
                 "takes": [ "pcf?" ],
                 "produces": [
@@ -85,7 +66,9 @@
                 }
             }
         },
+
         "prepare_sdc": {
+            "module": "common:generic_script_wrapper",
             "params": {
                 "stage_name": "prepare_sdc",
                 "interpreter": "${python3}",
@@ -107,7 +90,9 @@
                 }
             }
         },
+
         "pack": {
+            "module": "common:pack",
             "values": {
                 "device": "ql-eos-s3",
                 "device_alt": "ql-eos-s3_wlcsp",
@@ -142,7 +127,9 @@
                 }
             }
         },
+
         "ioplace": {
+            "module": "common:generic_script_wrapper",
             "params": {
                 "stage_name": "ioplace",
                 "interpreter": "${python3}",
@@ -162,7 +149,9 @@
                 }
             }
         },
+
         "place_constraints": {
+            "module": "common:generic_script_wrapper",
             "params": {
                 "stage_name": "place_constraints",
                 "interpreter": "${python3}",
@@ -181,7 +170,13 @@
                 }
             }
         },
+
+        "place": {
+            "module": "common:place"
+        },
+
         "iomux_jlink": {
+            "module": "common:generic_script_wrapper",
             "params": {
                 "stage_name": "iomux_jlink",
                 "interpreter": "${python3}",
@@ -201,7 +196,9 @@
                 }
             }
         },
+
         "iomux_openocd": {
+            "module": "common:generic_script_wrapper",
             "params": {
                 "stage_name": "iomux_openocd",
                 "interpreter": "${python3}",
@@ -221,7 +218,9 @@
                 }
             }
         },
+
         "iomux_binary": {
+            "module": "common:generic_script_wrapper",
             "params": {
                 "stage_name": "iomux_binary",
                 "interpreter": "${python3}",
@@ -241,7 +240,9 @@
                 }
             }
         },
+
         "route": {
+            "module": "common:route",
             "values": {
                 "device": "ql-eos-s3",
                 "device_alt": "ql-eos-s3_wlcsp",
@@ -276,7 +277,9 @@
                 }
             }
         },
+
         "analysis": {
+            "module": "common:analysis",
             "values": {
                 "device": "ql-eos-s3",
                 "device_alt": "ql-eos-s3_wlcsp",
@@ -315,7 +318,13 @@
                 }
             }
         },
+
+        "fasm": {
+            "module": "common:fasm"
+        },
+
         "bitstream": {
+            "module": "common:generic_script_wrapper",
             "params": {
                 "stage_name": "bitstream",
                 "script": "qlfasm",
@@ -340,7 +349,9 @@
                 "build_dir": "."
             }
         },
+
         "bitstream_bitheader": {
+            "module": "common:generic_script_wrapper",
             "params": {
                 "stage_name": "bitstream_bitheader",
                 "script": "symbiflow_write_bitheader",
@@ -362,7 +373,9 @@
                 }
             }
         },
+        
         "bitstream_jlink": {
+            "module": "common:generic_script_wrapper",
             "params": {
                 "stage_name": "bitstream_jlink",
                 "script": "symbiflow_write_jlink",
@@ -384,7 +397,9 @@
                 }
             }
         },
+
         "bitstream_openocd": {
+            "module": "common:generic_script_wrapper",
             "params": {
                 "stage_name": "bitstream_openocd",
                 "script": "symbiflow_write_openocd",
@@ -406,7 +421,9 @@
                 }
             }
         },
+
         "bitstream_binary": {
+            "module": "common:generic_script_wrapper",
             "params": {
                 "stage_name": "bitstream_binary",
                 "script": "symbiflow_write_binary",
@@ -428,7 +445,9 @@
                 }
             }
         },
+
         "fasm2bels": {
+            "module": "common:generic_script_wrapper",
             "params": {
                 "stage_name": "fasm2bels",
                 "script": "symbiflow_fasm2bels",

--- a/f4pga/platforms/ql-k4n8_fast.json
+++ b/f4pga/platforms/ql-k4n8_fast.json
@@ -1,16 +1,4 @@
 {
-    "stages": {
-        "mk_build_dir": "common:mkdirs",
-        "synth": "common:synth",
-        "pack": "common:pack",
-        "ioplace": "common:generic_script_wrapper",
-        "place": "common:place",
-        "repack": "common:generic_script_wrapper",
-        "route": "common:io_rename",
-        "fasm": "common:io_rename",
-        "bitstream": "common:generic_script_wrapper"
-    },
-
     "values": {
         "device": "qlf_k4n8_umc22",
         "rr_graph_lookahead_bin": "${shareDir}/arch/qlf_k4n8-qlf_k4n8_umc22_fast_qlf_k4n8-qlf_k4n8_umc22_fast/rr_graph_qlf_k4n8-qlf_k4n8_umc22_fast_qlf_k4n8-qlf_k4n8_umc22_fast.lookahead.bin",
@@ -33,13 +21,16 @@
         }
     },
 
-    "stage_options": {
+    "stages": {
         "mk_build_dir": {
+            "module": "common:mkdirs",
             "params": {
                 "build_dir": "build/${device}"
             }
         },
+
         "synth": {
+            "module": "common:synth",
             "params": {
                 "produces": [ "synth_v" ]
             },
@@ -56,7 +47,13 @@
                 }
             }
         },
+
+        "pack": {
+            "module": "common:pack"
+        },
+
         "ioplace": {
+            "module": "common:generic_script_wrapper",
             "params": {
                 "stage_name": "ioplace",
                 "interpreter": "${python3}",
@@ -77,10 +74,9 @@
                 }
             }
         },
+
         "repack": {
-            "values": {
-                "repacking_rules": "${shareDir}/arch/qlf_k4n8-qlf_k4n8_umc22_fast_qlf_k4n8-qlf_k4n8_umc22_fast/qlf_k4n8-qlf_k4n8_umc22_fast.repacking_rules.json"
-            },
+            "module": "common:generic_script_wrapper",
             "params": {
                 "stage_name": "repack",
                 "interpreter": "${python3}",
@@ -120,9 +116,18 @@
                     "pcf-constraints": "${pcf?}",
                     "$PYTHONPATH": "${binDir}/python/"
                 }
+            },
+            "values": {
+                "repacking_rules": "${shareDir}/arch/qlf_k4n8-qlf_k4n8_umc22_fast_qlf_k4n8-qlf_k4n8_umc22_fast/qlf_k4n8-qlf_k4n8_umc22_fast.repacking_rules.json"
             }
         },
+
+        "place": {
+            "module": "common:place"
+        },
+
         "route": {
+            "module": "common:io_rename",
             "params": {
                 "module": "common:route",
                 "rename_takes": {
@@ -132,7 +137,9 @@
                 }
             }
         },
+
         "fasm": {
+            "module": "common:io_rename",
             "params": {
                 "module": "common:fasm",
                 "rename_takes": {
@@ -142,7 +149,9 @@
                 }
             }
         },
+
         "bitstream": {
+            "module": "common:generic_script_wrapper",
             "params": {
                 "stage_name": "bitstream",
                 "script": "qlf_fasm",

--- a/f4pga/platforms/ql-k4n8_slow.json
+++ b/f4pga/platforms/ql-k4n8_slow.json
@@ -1,16 +1,4 @@
 {
-    "stages": {
-        "mk_build_dir": "common:mkdirs",
-        "synth": "common:synth",
-        "pack": "common:pack",
-        "ioplace": "common:generic_script_wrapper",
-        "place": "common:place",
-        "repack": "common:generic_script_wrapper",
-        "route": "common:io_rename",
-        "fasm": "common:io_rename",
-        "bitstream": "common:generic_script_wrapper"
-    },
-
     "values": {
         "device": "qlf_k4n8_umc22",
         "rr_graph_lookahead_bin": "${shareDir}/arch/qlf_k4n8-qlf_k4n8_umc22_slow_qlf_k4n8-qlf_k4n8_umc22_slow/rr_graph_qlf_k4n8-qlf_k4n8_umc22_slow_qlf_k4n8-qlf_k4n8_umc22_slow.lookahead.bin",
@@ -33,13 +21,16 @@
         }
     },
 
-    "stage_options": {
+    "stages": {
         "mk_build_dir": {
+            "module": "common:mkdirs",
             "params": {
                 "build_dir": "build/${device}"
             }
         },
+
         "synth": {
+            "common": "synth",
             "params": {
                 "produces": [ "synth_v" ]
             },
@@ -56,7 +47,13 @@
                 }
             }
         },
+
+        "pack": {
+            "module": "common:pack"
+        },
+
         "ioplace": {
+            "module": "common:generic_script_wrapper",
             "params": {
                 "stage_name": "ioplace",
                 "interpreter": "${python3}",
@@ -77,10 +74,9 @@
                 }
             }
         },
+
         "repack": {
-            "values": {
-                "repacking_rules": "${shareDir}/arch/qlf_k4n8-qlf_k4n8_umc22_slow_qlf_k4n8-qlf_k4n8_umc22_slow/qlf_k4n8-qlf_k4n8_umc22_slow.repacking_rules.json"
-            },
+            "module": "common:generic_script_wrapper",
             "params": {
                 "stage_name": "repack",
                 "interpreter": "${python3}",
@@ -120,9 +116,18 @@
                     "pcf-constraints": "${pcf?}",
                     "$PYTHONPATH": "${binDir}/python/"
                 }
+            },
+            "values": {
+                "repacking_rules": "${shareDir}/arch/qlf_k4n8-qlf_k4n8_umc22_slow_qlf_k4n8-qlf_k4n8_umc22_slow/qlf_k4n8-qlf_k4n8_umc22_slow.repacking_rules.json"
             }
         },
+
+        "place": {
+            "module": "common:place"
+        },
+
         "route": {
+            "module": "common:io_rename",
             "params": {
                 "module": "common:route",
                 "rename_takes": {
@@ -132,7 +137,9 @@
                 }
             }
         },
+
         "fasm": {
+            "module": "common:io_rename",
             "params": {
                 "module": "common:fasm",
                 "rename_takes": {
@@ -142,7 +149,9 @@
                 }
             }
         },
+
         "bitstream": {
+            "module": "common:generic_script_wrapper",
             "params": {
                 "stage_name": "bitstream",
                 "script": "qlf_fasm",

--- a/f4pga/platforms/xc7a100t.json
+++ b/f4pga/platforms/xc7a100t.json
@@ -37,24 +37,15 @@
     },
 
     "stages": {
-        "mk_build_dir": "common:mkdirs",
-        "synth": "common:synth",
-        "pack": "common:pack",
-        "ioplace": "common:generic_script_wrapper",
-        "place_constraints": "common:generic_script_wrapper",
-        "place": "common:place",
-        "route": "common:route",
-        "fasm": "common:fasm",
-        "bitstream": "common:generic_script_wrapper"
-    },
-
-    "stage_options": {
         "mk_build_dir": {
+            "module": "common:mkdirs",
             "params": {
                 "build_dir": "build/${device}"
             }
         },
+
         "synth": {
+            "module": "common:synth",
             "params": {
                 "takes": [ "xdc?" ],
                 "produces": [
@@ -84,7 +75,13 @@
                 }
             }
         },
+
+        "pack": {
+            "module": "common:pack"
+        },
+
         "ioplace": {
+            "module": "common:generic_script_wrapper",
             "params": {
                 "stage_name": "ioplace",
                 "interpreter": "${python3}",
@@ -104,7 +101,9 @@
                 }
             }
         },
+
         "place_constraints": {
+            "module": "common:generic_script_wrapper",
             "params": {
                 "stage_name": "place_constraints",
                 "interpreter": "${python3}",
@@ -127,7 +126,21 @@
                 }
             }
         },
+
+        "place": {
+            "module": "common:place"
+        },
+
+        "route": {
+            "module": "common:route"
+        },
+
+        "fasm": {
+            "module": "common:fasm"
+        },
+
         "bitstream": {
+            "module": "common:generic_script_wrapper",
             "params": {
                 "stage_name": "bitstream",
                 "script": "xcfasm",

--- a/f4pga/platforms/xc7a200t.json
+++ b/f4pga/platforms/xc7a200t.json
@@ -37,24 +37,15 @@
     },
 
     "stages": {
-        "mk_build_dir": "common:mkdirs",
-        "synth": "common:synth",
-        "pack": "common:pack",
-        "ioplace": "common:generic_script_wrapper",
-        "place_constraints": "common:generic_script_wrapper",
-        "place": "common:place",
-        "route": "common:route",
-        "fasm": "common:fasm",
-        "bitstream": "common:generic_script_wrapper"
-    },
-
-    "stage_options": {
         "mk_build_dir": {
+            "module": "common:mkdirs",
             "params": {
                 "build_dir": "build/${device}"
             }
         },
+        
         "synth": {
+            "module": "common:synth",
             "params": {
                 "takes": [ "xdc?" ],
                 "produces": [
@@ -84,7 +75,13 @@
                 }
             }
         },
+
+        "pack": {
+            "module": "common:pack"
+        },
+
         "ioplace": {
+            "module": "common:generic_script_wrapper",
             "params": {
                 "stage_name": "ioplace",
                 "interpreter": "${python3}",
@@ -104,7 +101,9 @@
                 }
             }
         },
+
         "place_constraints": {
+            "module": "common:generic_script_wrapper",
             "params": {
                 "stage_name": "place_constraints",
                 "interpreter": "${python3}",
@@ -127,7 +126,21 @@
                 }
             }
         },
+
+        "place": {
+            "module": "common:place"
+        },
+
+        "route": {
+            "module": "common:route"
+        },
+        
+        "fasm": {
+            "module": "common:fasm"
+        },
+
         "bitstream": {
+            "module": "common:generic_script_wrapper",
             "params": {
                 "stage_name": "bitstream",
                 "script": "xcfasm",

--- a/f4pga/platforms/xc7a50t.json
+++ b/f4pga/platforms/xc7a50t.json
@@ -1,16 +1,4 @@
 {
-    "stages": {
-        "mk_build_dir": "common:mkdirs",
-        "synth": "common:synth",
-        "pack": "common:pack",
-        "ioplace": "common:generic_script_wrapper",
-        "place_constraints": "common:generic_script_wrapper",
-        "place": "common:place",
-        "route": "common:route",
-        "fasm": "common:fasm",
-        "bitstream": "common:generic_script_wrapper"
-    },
-
     "values": {
         "device": "xc7a50t_test",
         "bitstream_device": "artix7",
@@ -48,13 +36,16 @@
         }
     },
 
-    "stage_options": {
+    "stages": {
         "mk_build_dir": {
+            "module": "common:mkdirs",
             "params": {
                 "build_dir": "build/${device}"
             }
         },
+
         "synth": {
+            "module": "common:synth",
             "params": {
                 "takes": [ "xdc?" ],
                 "produces": [
@@ -84,7 +75,13 @@
                 }
             }
         },
+
+        "pack": {
+            "module": "common:pack"
+        },
+
         "ioplace": {
+            "module": "common:generic_script_wrapper",
             "params": {
                 "stage_name": "ioplace",
                 "interpreter": "${python3}",
@@ -104,7 +101,9 @@
                 }
             }
         },
+
         "place_constraints": {
+            "module": "common:generic_script_wrapper",
             "params": {
                 "stage_name": "place_constraints",
                 "interpreter": "${python3}",
@@ -127,7 +126,21 @@
                 }
             }
         },
+
+        "place": {
+            "module": "common:place"
+        },
+
+        "route": {
+            "module": "common:route"
+        },
+
+        "fasm": {
+            "module": "common:fasm"
+        },
+
         "bitstream": {
+            "module": "common:generic_script_wrapper",
             "params": {
                 "stage_name": "bitstream",
                 "script": "xcfasm",

--- a/f4pga/stage.py
+++ b/f4pga/stage.py
@@ -60,15 +60,17 @@ class Stage:
     meta: 'dict[str, str]'     #   Stage's metadata extracted from module's
                                # output.
 
-    def __init__(self, name: str, modstr: str, mod_opts: 'dict[str, ] | None'):
-        if mod_opts is None:
-            mod_opts = {}
+    def __init__(self, name: str, stage_def: 'dict[str, ]'):
+        if stage_def is None:
+            stage_def = {}
+        
+        modstr = stage_def['module']
 
         module_path = resolve_modstr(modstr)
         ModuleClass = get_module(module_path)
-        self.module = ModuleClass(mod_opts.get('params'))
+        self.module = ModuleClass(stage_def.get('params'))
 
-        values = mod_opts.get('values')
+        values = stage_def.get('values')
         if values is not None:
             self.value_overrides = values
         else:


### PR DESCRIPTION
The current way in which stages were defined in flow definitions made it hard read what's going on, because  module names were listed separately from their configurations. This PR replace `stages` dict with what used to be in `stage_options` and adds additional `module` field to entries that used to be listed in `stage_options` dict.