### PR TITLE
docs/conf: update extlinks syntax

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -187,10 +187,10 @@ intersphinx_mapping = {
 # -- Sphinx.Ext.ExtLinks -----------------------------------------------------------------------------------------------
 
 extlinks = {
-   'wikipedia': ('https://en.wikipedia.org/wiki/%s', 'wikipedia:'),
-   'gh':        ('https://github.com/%s', 'gh:'),
-   'ghsharp':   ('https://github.com/chipsalliance/f4pga/issues/%s', '#'),
-   'ghissue':   ('https://github.com/chipsalliance/f4pga/issues/%s', 'issue #'),
-   'ghpull':    ('https://github.com/chipsalliance/f4pga/pull/%s', 'pull request #'),
-   'ghsrc':     ('https://github.com/chipsalliance/f4pga/blob/main/%s', '')
+   'wikipedia': ('https://en.wikipedia.org/wiki/%s', 'wikipedia: %s'),
+   'gh':        ('https://github.com/%s', 'gh:%s'),
+   'ghsharp':   ('https://github.com/chipsalliance/f4pga/issues/%s', '#%s'),
+   'ghissue':   ('https://github.com/chipsalliance/f4pga/issues/%s', 'issue #%s'),
+   'ghpull':    ('https://github.com/chipsalliance/f4pga/pull/%s', 'pull request #%s'),
+   'ghsrc':     ('https://github.com/chipsalliance/f4pga/blob/main/%s', '%s')
 }


### PR DESCRIPTION
This PR addresses the following warnings:

https://github.com/chipsalliance/f4pga/actions/runs/4218861868/jobs/7323688743#step:4:12
```
WARNING: extlinks: Sphinx-6.0 will require a caption string to contain exactly one '%s' and all other '%' need to be escaped as '%%'.
WARNING: extlinks: Sphinx-6.0 will require a caption string to contain exactly one '%s' and all other '%' need to be escaped as '%%'.
WARNING: extlinks: Sphinx-6.0 will require a caption string to contain exactly one '%s' and all other '%' need to be escaped as '%%'.
WARNING: extlinks: Sphinx-6.0 will require a caption string to contain exactly one '%s' and all other '%' need to be escaped as '%%'.
WARNING: extlinks: Sphinx-6.0 will require a caption string to contain exactly one '%s' and all other '%' need to be escaped as '%%'.
WARNING: extlinks: Sphinx-6.0 will require a caption string to contain exactly one '%s' and all other '%' need to be escaped as '%%'.
```