### PR TITLE
Fixed CLI override function

### DIFF
--- a/f4pga/flows/argparser.py
+++ b/f4pga/flows/argparser.py
@@ -239,7 +239,7 @@ def p_parse_cli_value(s: str):
     return s.replace("\\", "")
 
 
-def get_cli_flow_config(args: Namespace, part: str):
+def get_cli_flow_config(args: Namespace):
     def create_defdict():
         return {
             "dependencies": {},
@@ -261,4 +261,4 @@ def get_cli_flow_config(args: Namespace, part: str):
     add_entries(args.dep, "dependencies")
     add_entries(args.val, "values")
 
-    return {part: part_flow_config}
+    return part_flow_config

--- a/f4pga/flows/commands.py
+++ b/f4pga/flows/commands.py
@@ -224,7 +224,7 @@ def cmd_build(args: Namespace):
     if (project_flow_cfg is None) and part_name is None:
         fatal(-1, "No configuration was provided. Use `--flow`, and/or " "`--part` to configure flow.")
 
-    override_prj_flow_cfg_by_cli(project_flow_cfg, get_cli_flow_config(args, part_name))
+    project_flow_cfg = override_prj_flow_cfg_by_cli(project_flow_cfg, get_cli_flow_config(args))
 
     flow_cfg = make_flow_config(project_flow_cfg, part_name)
 

--- a/f4pga/flows/flow_config.py
+++ b/f4pga/flows/flow_config.py
@@ -131,51 +131,13 @@ class ProjectFlowConfig:
 
 
 def override_prj_flow_cfg_by_cli(cfg: ProjectFlowConfig, cli_d: "dict[str, dict[str, dict]]"):
-    for part_name, part_cfg in cli_d.items():
-        print(f"OVERRIDING CONFIG FOR {part_name}")
-        p_cfg = cfg.flow_cfg.get(part_name)
-        if p_cfg is None:
-            p_cfg = {}
-            cfg.flow_cfg[part_name] = p_cfg
-        cli_p_values = part_cfg.get("values")
-        cli_p_dependencies = part_cfg.get("dependencies")
-        p_values = p_cfg.get("values")
-        p_dependencies = p_cfg.get("dependencies")
-        if cli_p_values is not None:
-            if p_values is None:
-                p_values = {}
-                part_cfg["values"] = p_values
-            p_values.update(cli_p_values)
-        if cli_p_dependencies is not None:
-            if p_dependencies is None:
-                p_dependencies = {}
-                part_cfg["dependencies"] = p_dependencies
-            p_dependencies.update(cli_p_dependencies)
-
-        for stage_name, cli_stage_cfg in part_cfg.items():
-            if stage_name in KWORDS:
-                continue
-
-            stage_cfg = part_cfg.get(stage_name)
-            if stage_cfg is None:
-                stage_cfg = {}
-                part_cfg[stage_name] = stage_cfg
-
-            stage_values = stage_cfg.get("values")
-            stage_dependencies = stage_cfg.get("dependencies")
-            cli_stage_values = cli_stage_cfg.get("values")
-            cli_stage_dependencies = cli_stage_cfg.get("dependencies")
-
-            if cli_stage_values is not None:
-                if stage_values is None:
-                    stage_values = {}
-                    stage_cfg["values"] = stage_values
-                stage_values.update(cli_stage_values)
-            if cli_stage_dependencies is not None:
-                if stage_dependencies is None:
-                    stage_dependencies = {}
-                    stage_cfg["dependencies"] = stage_dependencies
-                stage_dependencies.update(cli_stage_dependencies)
+    if "dependencies" not in cfg.flow_cfg:
+        cfg.flow_cfg["dependencies"] = {}
+    if "values" not in cfg.flow_cfg:
+        cfg.flow_cfg["values"] = {}
+    cfg.flow_cfg["dependencies"] = {**cfg.flow_cfg["dependencies"], **cli_d["dependencies"]}
+    cfg.flow_cfg["values"] = {**cfg.flow_cfg["values"], **cli_d["values"]}
+    return cfg
 
 
 class FlowConfig:


### PR DESCRIPTION
This PR fixes a bug where you where not able to override top module from the CLI while using a flow file. For example like this:
`f4pga -vv build -f basys3.json -Dsources=[Blinky.sv] -Vtop=Blinky` 
This resulted in an error where tool would complain that no top module. The value from the top option was never passed to the flow configuration.